### PR TITLE
bumpup mlflow version to 1.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mlflow==1.9.1
+mlflow==1.10.0
 pysftp==0.2.9


### PR DESCRIPTION
MLflow 1.10.0 is released - https://mlflow.org/news/2020/07/20/1.10.0-release/index.html