### PR TITLE
Build identical docker image to open-datastudio/jupyter project

### DIFF
--- a/Dockerfile_staroid
+++ b/Dockerfile_staroid
@@ -5,7 +5,11 @@ RUN apt-get update && apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
 USER 1000
-ADD requirements.txt /home/jovyan/.requirements.txt
+
+# install gpu libs
+RUN conda install cudatoolkit=10.1 cudnn=7.6.5 --yes
+
+ADD --chown=1000:100 requirements.txt /home/jovyan/.requirements.txt
 RUN pip --no-cache-dir install -r /home/jovyan/.requirements.txt
 
 # mlflow creates new conda environment for run (i.e. mlflow run ...) and some dependencies need to be added.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Custom builder script for Skaffold
+# https://skaffold.dev/docs/pipeline-stages/builders/custom/
+#
+
+DOCKER_STACK_COMMIT=1a66dd36ff821bcef814afe86dbc3dba8cd2198d
+GPU_JUPYTER_COMMIT=3c350f0c933156edb49ebccb23142b890c232df6
+
+# Generate jupyter docker image using nvidia docker for gpu support.
+# Otherwise, Dockerfile_staroid would be enough.
+git clone https://github.com/iot-salzburg/gpu-jupyter.git
+cd gpu-jupyter
+git checkout $GPU_JUPYTER_COMMIT
+
+# generate Dockerfile
+./generate-Dockerfile.sh -c ${DOCKER_STACK_COMMIT} -s --no-datascience-notebook --no-useful-packages
+cd .build
+
+# patch Dockerfile. Want to keep minimal jupyter on gpu
+cat Dockerfile | awk '!p;/Dependency: jupyter\/scipy-notebook/{p=1}' > Dockerfile_minimal
+
+# append staroid Dockerfile
+cat ../../Dockerfile_staroid | grep -v ^FROM >> Dockerfile_minimal
+cp ../../requirements.txt ./
+cp -r ../../notebook ./notebook
+
+# print Dockerfile
+cat Dockerfile_minimal
+
+# build
+docker build -f Dockerfile_minimal -t $IMAGE .
+
+if $PUSH_IMAGE; then
+  docker push $IMAGE
+fi

--- a/k8s/ske.yaml
+++ b/k8s/ske.yaml
@@ -91,7 +91,7 @@ data:
         <br />
         <code>https://p5001-mlflow-serving--STAROID_SERVICE_DOMAIN/invocations</code>
         <br /><br />
-        <b>Internal</b> (from the same virtual cloud)
+        <b>Internal</b> (from the same Kubernetes cluster)
         <br />
         <code>http://mlflow-serving.NAMESPACE:5001/invocations</code>
         <br /><br /><br /><br />

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ build:
     - image: mlflow-serving
       context: .
       custom:
-        buildCommand: build.sh
+        buildCommand: ./build.sh
 deploy:
   kubectl:
     manifests:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,8 +4,8 @@ build:
   artifacts:
     - image: mlflow-serving
       context: .
-      docker:
-        dockerfile: Dockerfile
+      custom:
+        buildCommand: build.sh
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
open-datastudio/jupyter updated its python environment via https://github.com/open-datastudio/jupyter/pull/8 and https://github.com/open-datastudio/jupyter/pull/10.

Let's keep an identical environment here.